### PR TITLE
Remove shutdown event trigger

### DIFF
--- a/reboottoarpl/install.sh
+++ b/reboottoarpl/install.sh
@@ -4,7 +4,7 @@ if [ "${1}" = "late" ]; then
 if [ -f /tmpRoot/usr/syno/etc/esynoscheduler/esynoscheduler.db ]; then
 echo "insert RebootToArpl task"
 /tmpRoot/bin/sqlite3 /tmpRoot/usr/syno/etc/esynoscheduler/esynoscheduler.db <<EOF
-INSERT INTO task VALUES('RebootToArpl', '', 'shutdown', '', 0, 0, 0, 0, '', 0, '/usr/bin/arpl-reboot.sh "config"', 'script', '{}', '', '', '{}', '{}');
+INSERT INTO task VALUES('RebootToArpl', '', '-', '', 0, 0, 0, 0, '', 0, '/usr/bin/arpl-reboot.sh "config"', 'script', '{}', '', '', '{}', '{}');
 EOF
 else
 echo "copy RebootToArpl task db"


### PR DESCRIPTION
It shouldn't be repeated every time you shutdown.

I checked the contents of your apl-reboot.sh .
This script should not be run automatically by the scheduler whenever a shutdown event occurs.

https://github.com/wjz304/arpl-i18n/blob/main/files/board/arpl/overlayfs/usr/sbin/arpl-reboot.sh

By the way, has this arpl-reboot.sh ever been tested?
The path of this file is /usr/sbin/arpl-reboot.sh,
In the install.sh script
/usr/bin/arpl-reboot.sh
"INSERT INTO task VALUES('RebootToArpl', '', '-', '', 0, 0, 0, 0, '', 0, '/usr/bin/arpl-reboot.sh "config"', 'script', '{}', '', '', '{}', '{}');"
path is not correct.
Strange.